### PR TITLE
Smooth location updates animations

### DIFF
--- a/Sources/CustomAnnotatedMap/Models/MapRect.swift
+++ b/Sources/CustomAnnotatedMap/Models/MapRect.swift
@@ -59,3 +59,20 @@ extension MapRect: Hashable {
         hasher.combine(self.size.height)
     }
 }
+
+extension MapRect {
+    /// Compares two instances of MapRect with 0.0001 degrees precision (approx 10 metres)
+    /// Precision is set due to slight inaccuracies in MKMap region property during map movements
+    /// - Parameter mapRect: MapRect to compare
+    /// - Returns: The differences in centers and spans of the mapRects are smaller than 10 metres
+    func isSame(as mapRect: MapRect?) -> Bool {
+        guard let mapRect = mapRect else {
+            return false
+        }
+        
+        return (abs(mapRect.coordinateRegion.center.latitude - self.coordinateRegion.center.latitude) < 0.0001) &&
+        (abs(mapRect.coordinateRegion.center.longitude - self.coordinateRegion.center.longitude) < 0.0001) &&
+        (abs(mapRect.coordinateRegion.span.latitudeDelta - self.coordinateRegion.span.latitudeDelta) < 0.0001) &&
+        (abs(mapRect.coordinateRegion.span.longitudeDelta - self.coordinateRegion.span.longitudeDelta) < 0.0001)
+    }
+}

--- a/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
+++ b/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
@@ -6,6 +6,11 @@ extension _CustomAnnotatedMapContent {
 
     public class _CustomAnnotatedMapCoordinator: NSObject, MKMapViewDelegate {
         private var mapContent: _CustomAnnotatedMapContent
+        /// Determines if changes in map region are updated to the mapContent view
+        var listenToLocationChanges = false
+        
+        /// The latest map region that got updated to the mapContent view
+        var lastMapRect: MapRect?
 
         init(_ mapContent: _CustomAnnotatedMapContent<ID, Annotation>) {
             self.mapContent = mapContent
@@ -16,8 +21,16 @@ extension _CustomAnnotatedMapContent {
             _ mapView: MKMapView,
             regionDidChangeAnimated animated: Bool
         ) {
+            /*
+              Only update the map region changes to the mapContent if allowed.
+              This prevents updates during the manual changes to the map region and user tracking mode
+              which are animated and would be interrupted.
+             */
+            guard listenToLocationChanges else { return }
+            
             self.mapContent.coordinateRegion = CoordinateRegion(rawValue: mapView.region)
             self.mapContent.mapRect = MapRect.init(rawValue: mapView.visibleMapRect)
+            self.lastMapRect = MapRect.init(rawValue: mapView.visibleMapRect)
         }
 
         public func mapView(


### PR DESCRIPTION
The problem here was: 
- The `mapRect` or the `coordinateRegion` bindings were written to multiple times during the map animations (when `setRegion` or `setTrackingMode` were called) and also when the view got updated due to any different reason (= all the time). 

This led to laggy animations and unpredictable map region changes. 
I tried different approaches with custom bindings etc but those required the `CustomAnnotatedMap` init signature to be changed (which I did not want to). Finally I settled with this implementation which is maybe a bit simple but works nicely. 