### PR TITLE
Map annotations updating

### DIFF
--- a/Sources/CustomAnnotatedMap/_CustomAnnotatedMapContent.swift
+++ b/Sources/CustomAnnotatedMap/_CustomAnnotatedMapContent.swift
@@ -82,11 +82,10 @@ where
 
     public func makeUIView(context: Context) -> some MKMapView {
         let mapView = MKMapView(frame: .zero)
-        mapView.addAnnotations(
-            annotations
-                .mapValues(\.mkAnnotation)
-                .compactMap { $0.value as? MKAnnotation }
-        )
+        
+        updateAnnotationsIfNeeded(on: mapView,
+                                  with: context.coordinator)
+        
         mapView.register(
             CustomAnnotationView.self,
             forAnnotationViewWithReuseIdentifier: MKMapViewDefaultAnnotationViewReuseIdentifier
@@ -101,10 +100,14 @@ where
     }
 
     public func updateUIView(_ mapView: UIViewType, context: Context) {
+        
         if mapView.delegate == nil {
             mapView.delegate = context.coordinator
         }
-
+        
+        updateAnnotationsIfNeeded(on: mapView,
+                                  with: context.coordinator)
+        
         if mapView.showsUserLocation != self.showsUserLocation {
             mapView.showsUserLocation = self.showsUserLocation
         }
@@ -131,6 +134,26 @@ where
         }
     }
     
+    
+    /// Checks if the current annotations reflect the annotations displayed in the map and updates accordingly
+    /// - Parameters:
+    ///   - mapView: The MKMapView associated with this UIViewRepresentable
+    ///   - coordinator: The associated coordinator object
+    private func updateAnnotationsIfNeeded(on mapView: MKMapView, with coordinator: Coordinator) {
+        let annotationsIds = Set(annotations.map { $0.key})
+        
+        if coordinator.displayedAnnotationsIDs != annotationsIds {
+            mapView.removeAnnotations(mapView.annotations)
+            
+            mapView.addAnnotations(
+                annotations
+                    .mapValues(\.mkAnnotation)
+                    .compactMap { $0.value as? MKAnnotation }
+            )
+            
+            coordinator.displayedAnnotationsIDs = annotationsIds
+        }
+    }
     
     /// Moves the map to a coordinate region
     /// - Parameters:

--- a/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
+++ b/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
@@ -11,6 +11,9 @@ extension _CustomAnnotatedMapContent {
         
         /// The latest map region that got updated to the mapContent view
         var lastMapRect: MapRect?
+        
+        /// The IDs of the annotations currently displayed in the mapContent view
+        var displayedAnnotationsIDs: Set<ID> = []
 
         init(_ mapContent: _CustomAnnotatedMapContent<ID, Annotation>) {
             self.mapContent = mapContent


### PR DESCRIPTION
Previously the annotation updates were not reflected in the map view. 

Eg. when making an async call to fetch the annotations after the map was already loaded, the annotations were not displayed in the map. 