### PR TITLE
Annotation selected content

### DIFF
--- a/Sources/CustomAnnotatedMap/Annotations/MapAnnotation.swift
+++ b/Sources/CustomAnnotatedMap/Annotations/MapAnnotation.swift
@@ -15,7 +15,7 @@ where
         anchorPoint: CGPoint = .init(x: 0.5, y: 0.5),
         @ViewBuilder content: () -> Content,
         @ViewBuilder selectedContent: () ->	SelectedContent,
-        @ViewBuilder contentCluster: () -> ContentCluster
+        @ViewBuilder contentCluster: @escaping ((Int) -> ContentCluster)
     ) {
         self.mkAnnotation = _CustomMKAnnotation.init(
             coordinate: location.coordinate,
@@ -23,7 +23,7 @@ where
             anchorPoint: anchorPoint,
             content: content(),
             selectedContent: selectedContent(),
-            contentCluster: contentCluster()
+            contentCluster: contentCluster
         )
     }
 }

--- a/Sources/CustomAnnotatedMap/Annotations/MapAnnotation.swift
+++ b/Sources/CustomAnnotatedMap/Annotations/MapAnnotation.swift
@@ -20,6 +20,7 @@ where
         self.mkAnnotation = _CustomMKAnnotation.init(
             coordinate: location.coordinate,
             clusteringIdentifier: clusteringIdentifier,
+            anchorPoint: anchorPoint,
             content: content(),
             selectedContent: selectedContent(),
             contentCluster: contentCluster()
@@ -42,6 +43,7 @@ where
     ) {
         self.mkAnnotation = _CustomMKAnnotation.init(
             coordinate: location.coordinate,
+            anchorPoint: anchorPoint,
             content: content(),
             selectedContent: selectedContent()
         )

--- a/Sources/CustomAnnotatedMap/Annotations/_CustomMKAnnotation.swift
+++ b/Sources/CustomAnnotatedMap/Annotations/_CustomMKAnnotation.swift
@@ -10,14 +10,17 @@ public class _CustomMKAnnotation<Content, SelectedContent, ContentCluster>: NSOb
     let content: Content
     let selectedContent: SelectedContent?
     let contentCluster: ContentCluster?
+    let anchorPoint: CGPoint
 
     init(
         coordinate: CLLocationCoordinate2D,
         clusteringIdentifier: String? = nil,
+        anchorPoint: CGPoint,
         content: Content,
         selectedContent: SelectedContent,
         contentCluster: ContentCluster? = nil
     ) {
+        self.anchorPoint = anchorPoint
         self.coordinate = coordinate
         self.clusteringIdentifier = clusteringIdentifier
         self.content = content
@@ -51,26 +54,36 @@ where
         }
         self.notSelectedView = UIHostingController(rootView: customMKAnnotation.content.ignoresSafeArea()).view
         self.selectedView = UIHostingController(rootView: customMKAnnotation.selectedContent.ignoresSafeArea()).view
+        notSelectedView.backgroundColor = .clear
+        selectedView.backgroundColor = .clear
+        
         super.init(
             annotation: customMKAnnotation,
             reuseIdentifier: "customAnnotationViewReuseIdentifier"
         )
+        
         self.clusteringIdentifier = customMKAnnotation.clusteringIdentifier
-        self.addSubview(notSelectedView)
+        frame = CGRect(x: 0, y: 0, width: 30, height: 40)
+
+        centerOffset = CGPoint(x: 0, y: -frame.size.height)
+        addSubview(notSelectedView)
+        notSelectedView.frame = bounds
     }
+    
+    
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
-        // Toogles the selection views 
+        // Toogles the selection views
         if selected {
-            self.addSubview(selectedView)
-            notSelectedView.removeFromSuperview()
+            addSubview(selectedView)
+            selectedView.frame = bounds
         } else {
-            self.addSubview(notSelectedView)
-            selectedView.removeFromSuperview()
+            addSubview(notSelectedView)
+            notSelectedView.frame = bounds
         }
     }
 }

--- a/Sources/CustomAnnotatedMap/Annotations/_CustomMKAnnotation.swift
+++ b/Sources/CustomAnnotatedMap/Annotations/_CustomMKAnnotation.swift
@@ -9,7 +9,7 @@ public class _CustomMKAnnotation<Content, SelectedContent, ContentCluster>: NSOb
     let clusteringIdentifier: String?
     let content: Content
     let selectedContent: SelectedContent?
-    let contentCluster: ContentCluster?
+    let contentCluster: ((Int) -> ContentCluster)?
     let anchorPoint: CGPoint
 
     init(
@@ -18,8 +18,8 @@ public class _CustomMKAnnotation<Content, SelectedContent, ContentCluster>: NSOb
         anchorPoint: CGPoint,
         content: Content,
         selectedContent: SelectedContent,
-        contentCluster: ContentCluster? = nil
-    ) {
+        contentCluster: ((Int) -> ContentCluster)? = nil
+    ){
         self.anchorPoint = anchorPoint
         self.coordinate = coordinate
         self.clusteringIdentifier = clusteringIdentifier
@@ -115,7 +115,8 @@ where
             annotation: cluster,
             reuseIdentifier: "customClusterAnnotationViewReuseIdentifier"
         )
-        self.addSubview(UIHostingController(rootView: contentCluster.ignoresSafeArea()).view)
+        
+        self.addSubview(UIHostingController(rootView: contentCluster(members.count).ignoresSafeArea()).view)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
+++ b/Sources/CustomAnnotatedMap/_CustomAnnotatedMapCoordinator.swift
@@ -71,7 +71,9 @@ extension _CustomAnnotatedMapContent {
             animated: Bool
         ) {
             if let userTrackingMode = UserTrackingMode(rawValue: mode.rawValue) {
-                self.mapContent.userTrackingMode = userTrackingMode
+                DispatchQueue.main.async {                
+                    self.mapContent.userTrackingMode = userTrackingMode
+                }
             }
         }
     }


### PR DESCRIPTION
Annotation selection. Currently more a workaround than a complete solution. The annotations are still not pinned correctly and can change their position slightly when the map view is reloaded or when zooming.

This happens because we add the custom annotation views as a subview to the MKAnnotationView. A better solution would probably be to convert the custom annotation view to an `UIImage` and then assign this to the `MKMapView.image` property (as used normally with `MKMapView`). 